### PR TITLE
Updated for 0.5 compatibility 

### DIFF
--- a/src/blockCG.jl
+++ b/src/blockCG.jl
@@ -24,7 +24,7 @@ Input:
 	X           - array of starting guesses (will be overwritten)
 	out         - flag for output (-1: no output, 0: only errors, 1: final status, 2: residual norm at each iteration)
 	ortho       - flag for re-orthogonalization (default: false)
-	pinvTol     - tolerance for pseudoinverse (default: eps(T)*size(B,1))
+	pinvTol     - tolerance for pseudoinverse (default: eps(T)\*size(B,1))
 	storeInterm - flag for storing iterates (default: false)
 
 Output:
@@ -137,7 +137,7 @@ function computeNorm(R)
 			res[k]+=R[i,k]*R[i,k]
 		end
 	end
-	return sqrt(res)
+	return sqrt.(res)
 end
 
 function getPinv!(A,pinvTol)
@@ -145,6 +145,6 @@ function getPinv!(A,pinvTol)
 	Sinv        = zeros(length(SVD.S))
     index       = SVD.S .> pinvTol*maximum(SVD.S)
     Sinv[index] = 1.0./ SVD.S[index]
-    Sinv[find(!isfinite(Sinv))] = 0.0
+    Sinv[find(.!isfinite.(Sinv))] = 0.0
     return SVD.Vt'*(Diagonal(Sinv)*SVD.U')
 end


### PR DESCRIPTION
Just had to change one line in the blockCG code and add in Compat. Tested on 0.5 and 0.4. The tests generate a bunch of method overwritten warnings on 0.5, all coming from bits of code like

```
A(x) = A*x
... (Generate new A somewhere during the ...)
A(x) = A*x
```

These warnings can be removed by replacing all such calls with the use of anonymous functions but I think the code is cleaner as is and the warnings aren't a big deal. Having said that fixing them wouldn't be a big deal either and I'm happy to do so if desired. These warnings are kind of annoying in this particular context but they've already proven useful to me in catching a potential bug elsewhere.
