### PR TITLE
Updated for Julia 0.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ os:
 
 julia:
   - 0.5
+  - 0.6
   - nightly
-  
+
 notifications:
   email: false
- 
+
 #script: # use the default script setting, which is equivalent to the following
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("KrylovMethods"); Pkg.test("KrylovMethods"; coverage=true)'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.5
+Compat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/KrylovMethods.jl
+++ b/src/KrylovMethods.jl
@@ -1,16 +1,17 @@
 module KrylovMethods
-	
+
 	import Base.BLAS
-	
+	using Compat
+
 	include("cg.jl")
 	include("blockCG.jl")
 	include("cgls.jl")
 	include("bicgstb.jl")
 	include("blockBiCGSTB.jl")
-	include("gmres.jl")	
+	include("gmres.jl")
 	include("lanczosBidiag.jl")
-	include("ssor.jl")	
-	include("lsqr.jl")	
+	include("ssor.jl")
+	include("lsqr.jl")
 	include("lanczosTridiag.jl")
 	include("lanczos.jl")
 	include("minres.jl")

--- a/src/blockCG.jl
+++ b/src/blockCG.jl
@@ -24,7 +24,7 @@ Input:
 	X           - array of starting guesses (will be overwritten)
 	out         - flag for output (-1: no output, 0: only errors, 1: final status, 2: residual norm at each iteration)
 	ortho       - flag for re-orthogonalization (default: false)
-	pinvTol     - tolerance for pseudoinverse (default: eps(T)*size(B,1))
+	pinvTol     - tolerance for pseudoinverse (default: eps(T)\*size(B,1))
 	storeInterm - flag for storing iterates (default: false)
 
 Output:
@@ -137,7 +137,7 @@ function computeNorm(R)
 			res[k]+=R[i,k]*R[i,k]
 		end
 	end
-	return sqrt(res)
+	return sqrt.(res)
 end
 
 function getPinv!(A,pinvTol)
@@ -145,6 +145,6 @@ function getPinv!(A,pinvTol)
 	Sinv        = zeros(length(SVD.S))
     index       = SVD.S .> pinvTol*maximum(SVD.S)
     Sinv[index] = 1.0./ SVD.S[index]
-    Sinv[find(!isfinite(Sinv))] = 0.0
+    Sinv[find(.!isfinite.(Sinv))] = 0.0
     return SVD.Vt'*(Diagonal(Sinv)*SVD.U')
 end


### PR DESCRIPTION
Fix sqrt broadcasting deprecation warning in blockCG. KrylovMethods now passes tests with no depwarns in 0.6